### PR TITLE
Feat/refactor config

### DIFF
--- a/src/command/build_project.rs
+++ b/src/command/build_project.rs
@@ -1,21 +1,26 @@
-use crate::{config, settings, terminal::ansi::ANSI_ERROR_STYLE};
+use crate::{
+    config::{Config, ProjectType},
+    settings::Settings,
+    terminal::ansi::ANSI_ERROR_STYLE,
+};
 use clap::ArgMatches;
 use fansi::{string::AnsiString, style::AnsiStyle};
-use std::{io::Write, path::Path};
+use std::io::Write;
+use std::path::Path;
 use walkdir::WalkDir;
 
 pub fn build_project(arg_matches: &ArgMatches) {
-    let config = config::read_config();
+    let config = Config::read();
 
     let out_file = match config.project_properties.project_type {
-        config::ProjectType::Binary => {
+        ProjectType::Binary => {
             if cfg!(windows) {
                 "app.exe"
             } else {
                 "app.AppImage"
             }
         }
-        config::ProjectType::Library => {
+        ProjectType::Library => {
             if arg_matches.get_flag("static-library") {
                 if cfg!(windows) {
                     "library.lib"
@@ -30,14 +35,8 @@ pub fn build_project(arg_matches: &ArgMatches) {
         }
     };
 
-    let out_dir = &config
-        .project_properties
-        .out_dir
-        .to_owned()
-        .unwrap_or_else(|| "out".to_string());
-
-    // TODO: There has got to be a better/safer way of doing this...
-    let out_file_path = std::path::Path::new("").join(out_dir);
+    let out_dir = config.out_dir();
+    let out_file_path = std::path::Path::new(&out_dir);
 
     std::fs::create_dir_all(&out_file_path)
         .expect("Failed to create output directories for compiler output file(s)!");
@@ -55,7 +54,7 @@ pub fn build_project(arg_matches: &ArgMatches) {
     execute_compiler(working_compiler_dir, project_args);
 }
 
-fn collect_cxx_file_paths(config: &config::Config, src_dir: &String) -> Vec<String> {
+fn collect_cxx_file_paths(config: &Config, src_dir: &String) -> Vec<String> {
     let mut paths: Vec<String> = Vec::new();
 
     let target_extension = match config.project_properties.language.to_lowercase().as_str() {
@@ -85,31 +84,23 @@ fn collect_cxx_file_paths(config: &config::Config, src_dir: &String) -> Vec<Stri
     paths
 }
 
-fn compute_compiler_args(config: &config::Config, out_file_path: String) -> Vec<String> {
+fn compute_compiler_args(config: &Config, out_file_path: String) -> Vec<String> {
     let mut project_args: Vec<String> = match config.project_properties.project_type {
-        config::ProjectType::Binary => vec!["-o", out_file_path.as_str()],
+        ProjectType::Binary => vec!["-o", out_file_path.as_str()],
         // TODO: For library building, there should be a way to distinguish static and dynamic libraries.
-        config::ProjectType::Library => vec!["-shared", "-o", out_file_path.as_str()],
+        ProjectType::Library => vec!["-shared", "-o", out_file_path.as_str()],
     }
     .into_iter()
     .map(String::from)
     .collect();
 
     // Collect C source files for inputting into the compiler.
-    let src_dir = &config
-        .project_properties
-        .src_dir
-        .to_owned()
-        .unwrap_or_else(|| "src".to_string());
-    let c_files = &mut collect_cxx_file_paths(config, src_dir);
+    let src_dir = config.src_dir();
+    let c_files = &mut collect_cxx_file_paths(config, &src_dir);
     project_args.append(c_files);
 
     // Try to append compiler arguments from config's compiler_args property.
-    if let Some(compiler_args) = config
-        .compiler_properties
-        .as_ref()
-        .and_then(|f| f.compiler_args.as_ref())
-    {
+    if let Some(compiler_args) = config.compiler_args() {
         let mut split_args: Vec<String> = compiler_args
             .split_whitespace()
             .into_iter()
@@ -121,43 +112,37 @@ fn compute_compiler_args(config: &config::Config, out_file_path: String) -> Vec<
     project_args
 }
 
-fn compute_working_compiler_dir(config: &config::Config) -> Option<String> {
+/// Tries to get a valid compiler directory, where 'valid' is a configured
+/// and existing directory
+fn compute_working_compiler_dir(config: &Config) -> String {
     // First try to use the project compiler directory.
-    let mut working_compiler_dir = config
-        .compiler_properties
-        .as_ref()
-        .and_then(|f| f.compiler_dir.to_owned());
-
-    match &working_compiler_dir {
-        // If the project compiler path does not exist, try checking the default compiler path.
-        Some(project_compiler_dir) => {
-            if !Path::new(project_compiler_dir).exists() {
-                read_default_compiler_dir(config, &mut working_compiler_dir);
-            }
+    if let Some(project_compiler_dir) = config.compiler_dir() {
+        if Path::new(&project_compiler_dir).exists() {
+            return project_compiler_dir.to_owned();
         }
-        None => read_default_compiler_dir(config, &mut working_compiler_dir),
     }
 
-    working_compiler_dir
-}
-
-fn read_default_compiler_dir(config: &config::Config, working_compiler_dir: &mut Option<String>) {
-    let settings = settings::read_settings();
-    let default_ccake_compiler_dir =
-        match config.project_properties.language.to_lowercase().as_str() {
-            "c" => settings.default_c_compiler_dir,
-            "c++" | "cpp" => settings.default_cpp_compiler_dir,
-            _ => panic!("Unknown project language specified in ccake.toml!"),
-        };
-    if !Path::new(&default_ccake_compiler_dir).exists() {
-        panic!("Failed to get a working compiler path for building!");
-    } else {
-        *working_compiler_dir = Some(default_ccake_compiler_dir);
+    // If project compiler directory is invalid, try using ccake's default settings
+    let settings = Settings::read();
+    let default_ccake_compiler_dir = read_default_compiler_dir(config, &settings);
+    if Path::new(&default_ccake_compiler_dir).exists() {
+        return default_ccake_compiler_dir;
     }
+
+    panic!("Failed to get a working compiler path for building!")
 }
 
-fn execute_compiler(working_compiler_dir: Option<String>, project_args: Vec<String>) {
-    let output = std::process::Command::new(&working_compiler_dir.unwrap())
+fn read_default_compiler_dir(config: &Config, settings: &Settings) -> String {
+    match config.project_properties.language.to_lowercase().as_str() {
+        "c" => &settings.default_c_compiler_dir,
+        "c++" | "cpp" => &settings.default_cpp_compiler_dir,
+        _ => panic!("Unknown project language specified in ccake.toml!"),
+    }
+    .to_owned()
+}
+
+fn execute_compiler(working_compiler_dir: String, project_args: Vec<String>) {
+    let output = std::process::Command::new(&working_compiler_dir)
         .args(project_args)
         .output()
         .expect("failed to execute compiler process!");

--- a/src/command/configure.rs
+++ b/src/command/configure.rs
@@ -1,9 +1,9 @@
 use clap::ArgMatches;
 
-use crate::settings::{read_settings, write_settings};
+use crate::settings::Settings;
 
 pub fn configure(arg_matches: &ArgMatches) {
-    let mut current_settings = &mut read_settings();
+    let mut current_settings = &mut Settings::read();
 
     if let Ok(Some(default_c_compiler_dir)) =
         arg_matches.try_get_one::<String>("default-c-compiler-dir")
@@ -17,5 +17,5 @@ pub fn configure(arg_matches: &ArgMatches) {
         current_settings.default_cpp_compiler_dir = default_cpp_compiler_dir.to_string();
     }
 
-    write_settings(current_settings);
+    Settings::write(current_settings);
 }

--- a/src/command/new_project.rs
+++ b/src/command/new_project.rs
@@ -1,35 +1,20 @@
 use clap::crate_version;
 
-use crate::config::write_config;
 use crate::terminal::ansi::error;
 use crate::terminal::prompt::prompt;
-use crate::{config, HELLO_C, HELLO_CPP};
+use crate::{config::Config, HELLO_C, HELLO_CPP};
 
 pub fn initialize_project(sub_path: Option<&String>) {
     let (project_name, project_language, project_version, project_authors) =
         prompt_user_for_project_details();
 
-    let config = config::Config {
-        project_properties: config::ProjectProperties {
-            project_name,
-            project_version,
-            authors: Some(
-                project_authors
-                    .trim()
-                    .split(',')
-                    .map(|f| f.trim().to_string())
-                    .collect(),
-            ),
-            ccake_version: crate_version!().to_string(),
-
-            language: project_language,
-            project_type: config::ProjectType::Binary,
-            src_dir: None,
-            out_dir: None,
-        },
-        compiler_properties: None,
-    };
-
+    let config = Config::new(
+        project_name,
+        project_version,
+        project_authors,
+        crate_version!().to_string(),
+        project_language,
+    );
     write_project_files(&config, sub_path);
 }
 
@@ -65,17 +50,13 @@ fn prompt_user_for_project_details() -> (String, String, String, String) {
     )
 }
 
-fn write_project_files(config: &config::Config, sub_path: Option<&String>) {
-    write_config(config, &sub_path);
+fn write_project_files(config: &Config, sub_path: Option<&String>) {
+    config.write(&sub_path);
     write_hello_world(config, &sub_path);
 }
 
-fn write_hello_world(config: &config::Config, sub_path: &Option<&String>) {
-    let src_dir = config
-        .project_properties
-        .src_dir
-        .to_owned()
-        .unwrap_or_else(|| "src".to_string());
+fn write_hello_world(config: &Config, sub_path: &Option<&String>) {
+    let src_dir = config.src_dir();
 
     let lowercase_language = config.project_properties.language.to_lowercase();
     let lang_str = lowercase_language.as_str();

--- a/src/config.rs
+++ b/src/config.rs
@@ -18,43 +18,104 @@ pub struct ProjectProperties {
 
     pub language: String,
     pub project_type: ProjectType,
-    pub src_dir: Option<String>,
-    pub out_dir: Option<String>,
+    src_dir: Option<String>,
+    out_dir: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct CompilerProperties {
-    pub compiler_dir: Option<String>,
-    pub compiler_args: Option<String>,
+    compiler_dir: Option<String>,
+    compiler_args: Option<String>,
 }
 
+/// Local properties for ccake project
+/// For global properties, see Settings
 #[derive(Debug, Deserialize, Serialize)]
 pub struct Config {
     pub project_properties: ProjectProperties,
     pub compiler_properties: Option<CompilerProperties>,
 }
 
-pub fn read_config() -> Config {
-    let mut file =
-        File::open(CCAKE_CONFIG_FILE_NAME).expect("Failed to open ccake.toml file for reading!");
-
-    let mut file_content = String::new();
-    file.read_to_string(&mut file_content)
-        .expect("Failed to read contents of ccake.toml file!");
-
-    toml::from_str(&file_content).expect("Failed to deserialize content from ccake.toml file!")
-}
-
-pub fn write_config(config: &Config, sub_path: &Option<&String>) {
-    let config_as_str = toml::to_string(&config).expect("Failed to serialize config to string!");
-
-    if let Some(path) = sub_path {
-        let ccake_path = format!("{}{}{}", path, "/", CCAKE_CONFIG_FILE_NAME);
-        std::fs::create_dir_all(path).expect("Failed to create directories to ccake.toml path!");
-        std::fs::write(ccake_path, config_as_str).expect("Failed to write to ccake.toml file!");
-        return;
+impl Config {
+    pub fn new(
+        project_name: String,
+        project_version: String,
+        project_authors: String,
+        ccake_version: String,
+        project_language: String,
+    ) -> Self {
+        Config {
+            project_properties: ProjectProperties {
+                project_name,
+                project_version,
+                authors: Some(
+                    project_authors
+                        .trim()
+                        .split(',')
+                        .map(|f| f.trim().to_string())
+                        .collect(),
+                ),
+                ccake_version,
+                language: project_language,
+                project_type: ProjectType::Binary,
+                src_dir: None,
+                out_dir: None,
+            },
+            compiler_properties: None,
+        }
     }
 
-    std::fs::write(CCAKE_CONFIG_FILE_NAME, config_as_str)
-        .expect("Failed to write to ccake.toml file!");
+    pub fn read() -> Self {
+        let mut file = File::open(CCAKE_CONFIG_FILE_NAME)
+            .expect("Failed to open ccake.toml file for reading!");
+
+        let mut file_content = String::new();
+        file.read_to_string(&mut file_content)
+            .expect("Failed to read contents of ccake.toml file!");
+
+        toml::from_str(&file_content).expect("Failed to deserialize content from ccake.toml file!")
+    }
+}
+
+impl Config {
+    pub fn write(&self, sub_path: &Option<&String>) {
+        let config_as_str = toml::to_string(&self).expect("Failed to serialize config to string!");
+
+        if let Some(path) = sub_path {
+            let ccake_path = format!("{}{}{}", path, "/", CCAKE_CONFIG_FILE_NAME);
+            std::fs::create_dir_all(path)
+                .expect("Failed to create directories to ccake.toml path!");
+            std::fs::write(ccake_path, config_as_str).expect("Failed to write to ccake.toml file!");
+            return;
+        }
+
+        std::fs::write(CCAKE_CONFIG_FILE_NAME, config_as_str)
+            .expect("Failed to write to ccake.toml file!");
+    }
+
+    pub fn out_dir(&self) -> String {
+        self.project_properties
+            .out_dir
+            .clone()
+            .unwrap_or_else(|| "out".to_string())
+    }
+
+    pub fn src_dir(&self) -> String {
+        self.project_properties
+            .src_dir
+            .to_owned()
+            .unwrap_or_else(|| "src".to_string())
+    }
+
+    pub fn compiler_dir(&self) -> Option<&String> {
+        self.compiler_properties
+            .as_ref()
+            .and_then(|f| f.compiler_dir.as_ref())
+    }
+
+    pub fn compiler_args(&self) -> Option<&String> {
+        self.compiler_properties
+            .as_ref()
+            .and_then(|f| f.compiler_args.as_ref())
+    }
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -3,6 +3,8 @@ use std::{fs::File, io::Read};
 
 use crate::terminal::ansi::warning;
 
+/// Global properties for ccake project
+/// For local properties, see Config
 #[derive(Debug, Deserialize, Serialize)]
 pub struct Settings {
     pub default_c_compiler_dir: String,
@@ -10,62 +12,66 @@ pub struct Settings {
 }
 static CCAKE_SETTINGS_FILE_NAME: &str = "settings.toml";
 
-pub fn read_settings() -> Settings {
-    let mut home_dir = dirs::home_dir().unwrap(); // TODO: Not safe.
-    home_dir.push(".ccake");
+impl Settings {
+    pub fn read() -> Settings {
+        let mut home_dir = dirs::home_dir().unwrap(); // TODO: Not safe.
+        home_dir.push(".ccake");
 
-    std::fs::create_dir_all(&home_dir)
-        .expect("Failed to create directories to settings.toml path!");
+        std::fs::create_dir_all(&home_dir)
+            .expect("Failed to create directories to settings.toml path!");
 
-    home_dir.push(CCAKE_SETTINGS_FILE_NAME);
+        home_dir.push(CCAKE_SETTINGS_FILE_NAME);
 
-    let default_settings = Settings {
-        default_c_compiler_dir: "/path/to/c-compiler".to_string(),
-        default_cpp_compiler_dir: "/path/to/cpp-compiler".to_string(),
-    };
+        let default_settings = Settings {
+            default_c_compiler_dir: "/path/to/c-compiler".to_string(),
+            default_cpp_compiler_dir: "/path/to/cpp-compiler".to_string(),
+        };
 
-    let default_settings_str =
-        toml::to_string(&default_settings).expect("Failed to serialize default .ccake settings!");
+        let default_settings_str = toml::to_string(&default_settings)
+            .expect("Failed to serialize default .ccake settings!");
 
-    // If the .ccake settings file does not exist, create it and write the default data into it.
-    // Otherwise, try to open the file and read into it.
-    if !home_dir.exists() {
-        // TODO: Make this constant somehow.
-        std::fs::write(home_dir, default_settings_str)
-            .expect("Failed to write to settings.toml file!");
-        default_settings
-    } else {
-        match File::open(home_dir) {
-            Ok(mut file) => {
-                let mut file_content = String::new();
-                let res = file.read_to_string(&mut file_content);
+        // If the .ccake settings file does not exist, create it and write the default data into it.
+        // Otherwise, try to open the file and read into it.
+        if !home_dir.exists() {
+            // TODO: Make this constant somehow.
+            std::fs::write(home_dir, default_settings_str)
+                .expect("Failed to write to settings.toml file!");
+            default_settings
+        } else {
+            match File::open(home_dir) {
+                Ok(mut file) => {
+                    let mut file_content = String::new();
+                    let res = file.read_to_string(&mut file_content);
 
-                if res.is_err() {
-                    warning("Failed to read text data from settings.toml, falling back on default settings.");
-                    file_content = default_settings_str;
+                    if res.is_err() {
+                        warning("Failed to read text data from settings.toml, falling back on default settings.");
+                        file_content = default_settings_str;
+                    }
+
+                    toml::from_str(&file_content).unwrap_or(default_settings)
                 }
-
-                toml::from_str(&file_content).unwrap_or(default_settings)
-            }
-            Err(_) => {
-                warning("Failed to open settings.toml file for reading, falling back on default settings.");
-                default_settings
+                Err(_) => {
+                    warning("Failed to open settings.toml file for reading, falling back on default settings.");
+                    default_settings
+                }
             }
         }
     }
 }
 
-pub fn write_settings(settings: &Settings) {
-    let settings_as_str =
-        toml::to_string(&settings).expect("Failed to serialize settings data to string!");
+impl Settings {
+    pub fn write(&self) {
+        let settings_as_str =
+            toml::to_string(&self).expect("Failed to serialize settings data to string!");
 
-    let mut home_dir = dirs::home_dir().unwrap(); // TODO: Not safe.
-    home_dir.push(".ccake");
+        let mut home_dir = dirs::home_dir().unwrap(); // TODO: Not safe.
+        home_dir.push(".ccake");
 
-    std::fs::create_dir_all(&home_dir)
-        .expect("Failed to create directories to settings.toml path!");
+        std::fs::create_dir_all(&home_dir)
+            .expect("Failed to create directories to settings.toml path!");
 
-    home_dir.push(CCAKE_SETTINGS_FILE_NAME);
+        home_dir.push(CCAKE_SETTINGS_FILE_NAME);
 
-    std::fs::write(home_dir, settings_as_str).expect("Failed to write to settings.toml file!");
+        std::fs::write(home_dir, settings_as_str).expect("Failed to write to settings.toml file!");
+    }
 }


### PR DESCRIPTION
## Description

Refactors config.rs and settings.rs with impl blocks

## What

- Move some logic from build_project.rs to Config and Settings structs 
- Add comments where necessary
- Add idiomatic `impl` blocks for the above structs with methods like `new` when necessary 

## Why

- To make it easier to use the Config and Settings structs
- To make it easier to read modules that use the above structs